### PR TITLE
Fix segfault in startup notification

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -5,7 +5,7 @@ MANPREFIX = ${PREFIX}/share/man
 # In dist tarballs, the version is stored in the VERSION files.
 VERSION := '$(shell [ -f VERSION ] && cat VERSION)'
 ifeq ('',$(VERSION))
-VERSION := $(shell git describe)
+VERSION := $(shell git describe --tags)
 endif
 
 # Xinerama, comment if you don't want it

--- a/dunst.c
+++ b/dunst.c
@@ -331,6 +331,7 @@ int main(int argc, char *argv[])
                 n->plain_text = true;
                 n->urgency = LOW;
                 n->icon = NULL;
+                n->raw_icon = NULL;
                 n->category = NULL;
                 n->msg = NULL;
                 n->dbus_client = NULL;


### PR DESCRIPTION
With the changes introduced in a6d9626c54aafdae5620edb02512105ad17735cf, the field `raw_icon` needs to be initialized while creating the startup notification to prevent a segfault.

This PR also includes a minor change to set the right `VERSION` when building directly from git.
